### PR TITLE
macOS: Lower maximum socket buffer size

### DIFF
--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -65,6 +65,9 @@
 extern "C" {
 #endif
 
+#undef OFI_MAX_SOCKET_BUF_SIZE /* override unix/osd.h */
+#define OFI_MAX_SOCKET_BUF_SIZE INT_MAX
+
 static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
 {
 	return -1;


### PR DESCRIPTION
In practice, macOS returns an error (Invalid argument) with socket
operations > 2GB. Lower the limit to avoid infinite retry loops.